### PR TITLE
Run tests on Python 3.13 release candidate

### DIFF
--- a/.github/workflows/test_examples.yml
+++ b/.github/workflows/test_examples.yml
@@ -1,4 +1,4 @@
-# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# This workflow will install Python dependencies, run tests, and lint with a variety of Python versions
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
 name: Python package
@@ -19,9 +19,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v3
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.9'
+        python-version: '3.13'
+        allow-prereleases: true
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip


### PR DESCRIPTION
* https://www.python.org/download/pre-releases
* https://github.com/actions/setup-python/blob/main/docs/advanced-usage.md#allow-pre-releases

Blocked by:
* python-greenlet/greenlet#396