### PR TITLE
modify tacm12k and result

### DIFF
--- a/examples/bridge/bridge_tacm12k.py
+++ b/examples/bridge/bridge_tacm12k.py
@@ -2,12 +2,11 @@
 # ArXiv: https://arxiv.org/abs/2407.20157
 
 # Datasets  TACM12K
-# Acc       0.254
+# Acc       0.324
 
 import time
 import argparse
 import os.path as osp
-from numpy import dtype, size
 import pandas as pd
 import sys
 sys.path.append('../')

--- a/rllm/datasets/sjtutables/tacm12k.py
+++ b/rllm/datasets/sjtutables/tacm12k.py
@@ -112,7 +112,7 @@ class TACM12KDataset(Dataset):
         path = osp.join(self.raw_dir, self.raw_filenames[0])
         paper_df = pd.read_csv(path, index_col=['paper_id'])
         col_types = {
-            "year": ColType.NUMERICAL,
+            "year": ColType.CATEGORICAL,
             "conference": ColType.CATEGORICAL,
             "title": ColType.CATEGORICAL,
             "abstract": ColType.CATEGORICAL,


### PR DESCRIPTION
Fixed the problem of setting the year feature as Numerical when loading TACM12k data set. It is now Categorical. The results of the BRIDGE method in the example on this dataset are also updated.