### PR TITLE
Add lazy imports for package exports.

### DIFF
--- a/rllm/data/__init__.py
+++ b/rllm/data/__init__.py
@@ -1,31 +1,79 @@
-# BUG: This will occur circular import
-# from ..datasets.dataset import Dataset  # noqa
-from .graph_data import BaseGraph, GraphData, HeteroGraphData  # noqa
-from .table_data import BaseTable, TableData, TableDataset, TextEmbedderConfig  # noqa
-from .storage import BaseStorage, NodeStorage, EdgeStorage, recursive_apply  # noqa
-from .view import MappingView, KeysView, ValuesView, ItemsView  # noqa
+from importlib import import_module
+from typing import TYPE_CHECKING
 
+
+if TYPE_CHECKING:
+    from rllm.data.graph_data import (
+        BaseGraph,
+        GraphData,
+        HeteroGraphData,
+    )
+    from rllm.data.table_data import (
+        BaseTable,
+        TableData,
+        TableDataset,
+        TextEmbedderConfig,
+    )
+    from rllm.data.storage import (
+        BaseStorage,
+        NodeStorage,
+        EdgeStorage,
+        recursive_apply,
+    )
+    from rllm.data.view import (
+        MappingView,
+        KeysView,
+        ValuesView,
+        ItemsView,
+    )
+
+_LAZY_MODULES = {
+    "rllm.data.graph_data": (
+        "BaseGraph",
+        "GraphData",
+        "HeteroGraphData",
+    ),
+    "rllm.data.table_data": (
+        "BaseTable",
+        "TableData",
+        "TableDataset",
+        "TextEmbedderConfig",
+    ),
+    "rllm.data.storage": (
+        "BaseStorage",
+        "NodeStorage",
+        "EdgeStorage",
+        "recursive_apply",
+    ),
+    "rllm.data.view": (
+        "MappingView",
+        "KeysView",
+        "ValuesView",
+        "ItemsView",
+    ),
+}
 
 __all__ = [
-    # dataset_classes
-    # "Dataset",
-    # graph_data_classes
-    "BaseGraph",
-    "GraphData",
-    "HeteroGraphData",
-    # table_data_classes
-    "BaseTable",
-    "TableData",
-    "TableDataset",
-    "TextEmbedderConfig",
-    # storage_classes
-    "BaseStorage",
-    "NodeStorage",
-    "EdgeStorage",
-    "recursive_apply",
-    # view_classes
-    "MappingView",
-    "KeysView",
-    "ValuesView",
-    "ItemsView",
+    name
+    for names in _LAZY_MODULES.values()
+    for name in names
 ]
+
+_LAZY_ATTRS = {
+    name: module_name
+    for module_name, names in _LAZY_MODULES.items()
+    for name in names
+}
+
+
+def __getattr__(name):
+    if name in _LAZY_ATTRS:
+        module = import_module(_LAZY_ATTRS[name])
+        value = getattr(module, name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__))

--- a/rllm/data/__init__.py
+++ b/rllm/data/__init__.py
@@ -1,5 +1,6 @@
-from importlib import import_module
 from typing import TYPE_CHECKING
+
+from rllm.utils.lazy_imports import define_lazy_imports
 
 
 if TYPE_CHECKING:
@@ -53,27 +54,8 @@ _LAZY_MODULES = {
     ),
 }
 
-__all__ = [
-    name
-    for names in _LAZY_MODULES.values()
-    for name in names
-]
-
-_LAZY_ATTRS = {
-    name: module_name
-    for module_name, names in _LAZY_MODULES.items()
-    for name in names
-}
-
-
-def __getattr__(name):
-    if name in _LAZY_ATTRS:
-        module = import_module(_LAZY_ATTRS[name])
-        value = getattr(module, name)
-        globals()[name] = value
-        return value
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-
-def __dir__():
-    return sorted(set(globals()) | set(__all__))
+__all__, __getattr__, __dir__ = define_lazy_imports(
+    __name__,
+    globals(),
+    _LAZY_MODULES,
+)

--- a/rllm/dataloader/__init__.py
+++ b/rllm/dataloader/__init__.py
@@ -1,9 +1,45 @@
-from .neighbor_loader import NeighborLoader
-from .bridge_loader import BRIDGELoader
-from .relbench_loader import RelbenchLoader
+from importlib import import_module
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from rllm.dataloader.neighbor_loader import NeighborLoader
+    from rllm.dataloader.bridge_loader import BRIDGELoader
+    from rllm.dataloader.relbench_loader import RelbenchLoader
+
+_LAZY_MODULES = {
+    "rllm.dataloader.neighbor_loader": (
+        "NeighborLoader",
+    ),
+    "rllm.dataloader.bridge_loader": (
+        "BRIDGELoader",
+    ),
+    "rllm.dataloader.relbench_loader": (
+        "RelbenchLoader",
+    ),
+}
 
 __all__ = [
-    "NeighborLoader",
-    "BRIDGELoader",
-    "RelbenchLoader",
+    name
+    for names in _LAZY_MODULES.values()
+    for name in names
 ]
+
+_LAZY_ATTRS = {
+    name: module_name
+    for module_name, names in _LAZY_MODULES.items()
+    for name in names
+}
+
+
+def __getattr__(name):
+    if name in _LAZY_ATTRS:
+        module = import_module(_LAZY_ATTRS[name])
+        value = getattr(module, name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__))

--- a/rllm/dataloader/__init__.py
+++ b/rllm/dataloader/__init__.py
@@ -1,5 +1,6 @@
-from importlib import import_module
 from typing import TYPE_CHECKING
+
+from rllm.utils.lazy_imports import define_lazy_imports
 
 
 if TYPE_CHECKING:
@@ -19,27 +20,8 @@ _LAZY_MODULES = {
     ),
 }
 
-__all__ = [
-    name
-    for names in _LAZY_MODULES.values()
-    for name in names
-]
-
-_LAZY_ATTRS = {
-    name: module_name
-    for module_name, names in _LAZY_MODULES.items()
-    for name in names
-}
-
-
-def __getattr__(name):
-    if name in _LAZY_ATTRS:
-        module = import_module(_LAZY_ATTRS[name])
-        value = getattr(module, name)
-        globals()[name] = value
-        return value
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-
-def __dir__():
-    return sorted(set(globals()) | set(__all__))
+__all__, __getattr__, __dir__ = define_lazy_imports(
+    __name__,
+    globals(),
+    _LAZY_MODULES,
+)

--- a/rllm/dataloader/sampler/__init__.py
+++ b/rllm/dataloader/sampler/__init__.py
@@ -1,8 +1,45 @@
-from .data_type import NodeSamplerInput, HeteroSamplerOutput
-from .hetero_sampler import HeteroSampler
+from importlib import import_module
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from rllm.dataloader.sampler.data_type import (
+        NodeSamplerInput,
+        HeteroSamplerOutput,
+    )
+    from rllm.dataloader.sampler.hetero_sampler import HeteroSampler
+
+_LAZY_MODULES = {
+    "rllm.dataloader.sampler.data_type": (
+        "NodeSamplerInput",
+        "HeteroSamplerOutput",
+    ),
+    "rllm.dataloader.sampler.hetero_sampler": (
+        "HeteroSampler",
+    ),
+}
 
 __all__ = [
-    "NodeSamplerInput",
-    "HeteroSamplerOutput",
-    "HeteroSampler",
+    name
+    for names in _LAZY_MODULES.values()
+    for name in names
 ]
+
+_LAZY_ATTRS = {
+    name: module_name
+    for module_name, names in _LAZY_MODULES.items()
+    for name in names
+}
+
+
+def __getattr__(name):
+    if name in _LAZY_ATTRS:
+        module = import_module(_LAZY_ATTRS[name])
+        value = getattr(module, name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__))

--- a/rllm/dataloader/sampler/__init__.py
+++ b/rllm/dataloader/sampler/__init__.py
@@ -1,5 +1,6 @@
-from importlib import import_module
 from typing import TYPE_CHECKING
+
+from rllm.utils.lazy_imports import define_lazy_imports
 
 
 if TYPE_CHECKING:
@@ -19,27 +20,8 @@ _LAZY_MODULES = {
     ),
 }
 
-__all__ = [
-    name
-    for names in _LAZY_MODULES.values()
-    for name in names
-]
-
-_LAZY_ATTRS = {
-    name: module_name
-    for module_name, names in _LAZY_MODULES.items()
-    for name in names
-}
-
-
-def __getattr__(name):
-    if name in _LAZY_ATTRS:
-        module = import_module(_LAZY_ATTRS[name])
-        value = getattr(module, name)
-        globals()[name] = value
-        return value
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-
-def __dir__():
-    return sorted(set(globals()) | set(__all__))
+__all__, __getattr__, __dir__ = define_lazy_imports(
+    __name__,
+    globals(),
+    _LAZY_MODULES,
+)

--- a/rllm/datasets/__init__.py
+++ b/rllm/datasets/__init__.py
@@ -1,5 +1,6 @@
-from importlib import import_module
 from typing import TYPE_CHECKING
+
+from rllm.utils.lazy_imports import define_lazy_imports
 
 
 if TYPE_CHECKING:
@@ -99,27 +100,8 @@ _LAZY_MODULES = {
     ),
 }
 
-__all__ = [
-    name
-    for names in _LAZY_MODULES.values()
-    for name in names
-]
-
-_LAZY_ATTRS = {
-    name: module_name
-    for module_name, names in _LAZY_MODULES.items()
-    for name in names
-}
-
-
-def __getattr__(name):
-    if name in _LAZY_ATTRS:
-        module = import_module(_LAZY_ATTRS[name])
-        value = getattr(module, name)
-        globals()[name] = value
-        return value
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-
-def __dir__():
-    return sorted(set(globals()) | set(__all__))
+__all__, __getattr__, __dir__ = define_lazy_imports(
+    __name__,
+    globals(),
+    _LAZY_MODULES,
+)

--- a/rllm/datasets/__init__.py
+++ b/rllm/datasets/__init__.py
@@ -1,53 +1,125 @@
-from .adult import Adult
-from .bank_marketing import BankMarketing
-from .churn_modelling import ChurnModelling
-from .dblp import DBLP
-from .imdb import IMDB
-from .jannis import Jannis
-from .planetoid import PlanetoidDataset
-from .sjtutables.tml1m import TML1MDataset
-from .sjtutables.tlf2k import TLF2KDataset
-from .sjtutables.tacm12k import TACM12KDataset
-from .tape import TAPEDataset
-from .titanic import Titanic
-from .tagdataset import TAGDataset
-from .relbench.base import (
-    RelBenchDataset,
-    RelBenchTask,
-    RelBenchTaskType,
-    RelBenchTableMeta
-)
-from .relbench.f1 import RelF1Dataset
-from .lakemlb.mstraffic import MSTrafficDataset
-from .lakemlb.ncbuilding import NCBuildingDataset
-from .lakemlb.gacars import GACarsDataset
-from .lakemlb.nnstocks import NNStocksDataset
-from .lakemlb.lhstocks import LHStocksDataset
-from .lakemlb.dsmusic import DSMusicDataset
+from importlib import import_module
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from rllm.datasets.adult import Adult
+    from rllm.datasets.bank_marketing import BankMarketing
+    from rllm.datasets.churn_modelling import ChurnModelling
+    from rllm.datasets.dblp import DBLP
+    from rllm.datasets.imdb import IMDB
+    from rllm.datasets.jannis import Jannis
+    from rllm.datasets.planetoid import PlanetoidDataset
+    from rllm.datasets.sjtutables.tml1m import TML1MDataset
+    from rllm.datasets.sjtutables.tlf2k import TLF2KDataset
+    from rllm.datasets.sjtutables.tacm12k import TACM12KDataset
+    from rllm.datasets.tape import TAPEDataset
+    from rllm.datasets.titanic import Titanic
+    from rllm.datasets.tagdataset import TAGDataset
+    from rllm.datasets.relbench.base import (
+        RelBenchDataset,
+        RelBenchTask,
+        RelBenchTaskType,
+        RelBenchTableMeta,
+    )
+    from rllm.datasets.relbench.f1 import RelF1Dataset
+    from rllm.datasets.lakemlb.mstraffic import MSTrafficDataset
+    from rllm.datasets.lakemlb.ncbuilding import NCBuildingDataset
+    from rllm.datasets.lakemlb.gacars import GACarsDataset
+    from rllm.datasets.lakemlb.nnstocks import NNStocksDataset
+    from rllm.datasets.lakemlb.lhstocks import LHStocksDataset
+    from rllm.datasets.lakemlb.dsmusic import DSMusicDataset
+
+_LAZY_MODULES = {
+    "rllm.datasets.adult": (
+        "Adult",
+    ),
+    "rllm.datasets.bank_marketing": (
+        "BankMarketing",
+    ),
+    "rllm.datasets.churn_modelling": (
+        "ChurnModelling",
+    ),
+    "rllm.datasets.dblp": (
+        "DBLP",
+    ),
+    "rllm.datasets.imdb": (
+        "IMDB",
+    ),
+    "rllm.datasets.jannis": (
+        "Jannis",
+    ),
+    "rllm.datasets.planetoid": (
+        "PlanetoidDataset",
+    ),
+    "rllm.datasets.sjtutables.tml1m": (
+        "TML1MDataset",
+    ),
+    "rllm.datasets.sjtutables.tlf2k": (
+        "TLF2KDataset",
+    ),
+    "rllm.datasets.sjtutables.tacm12k": (
+        "TACM12KDataset",
+    ),
+    "rllm.datasets.tape": (
+        "TAPEDataset",
+    ),
+    "rllm.datasets.titanic": (
+        "Titanic",
+    ),
+    "rllm.datasets.tagdataset": (
+        "TAGDataset",
+    ),
+    "rllm.datasets.relbench.base": (
+        "RelBenchDataset",
+        "RelBenchTask",
+        "RelBenchTaskType",
+        "RelBenchTableMeta",
+    ),
+    "rllm.datasets.relbench.f1": (
+        "RelF1Dataset",
+    ),
+    "rllm.datasets.lakemlb.mstraffic": (
+        "MSTrafficDataset",
+    ),
+    "rllm.datasets.lakemlb.ncbuilding": (
+        "NCBuildingDataset",
+    ),
+    "rllm.datasets.lakemlb.gacars": (
+        "GACarsDataset",
+    ),
+    "rllm.datasets.lakemlb.nnstocks": (
+        "NNStocksDataset",
+    ),
+    "rllm.datasets.lakemlb.lhstocks": (
+        "LHStocksDataset",
+    ),
+    "rllm.datasets.lakemlb.dsmusic": (
+        "DSMusicDataset",
+    ),
+}
 
 __all__ = [
-    "Adult",
-    "BankMarketing",
-    "ChurnModelling",
-    "DBLP",
-    "IMDB",
-    "Jannis",
-    "PlanetoidDataset",
-    "TML1MDataset",
-    "TAPEDataset",
-    "Titanic",
-    "TAGDataset",
-    "TLF2KDataset",
-    "TACM12KDataset",
-    "RelBenchDataset",
-    "RelF1Dataset",
-    "RelBenchTask",
-    "RelBenchTaskType",
-    "RelBenchTableMeta",
-    "MSTrafficDataset",
-    "NCBuildingDataset",
-    "GACarsDataset",
-    "NNStocksDataset",
-    "LHStocksDataset",
-    "DSMusicDataset",
+    name
+    for names in _LAZY_MODULES.values()
+    for name in names
 ]
+
+_LAZY_ATTRS = {
+    name: module_name
+    for module_name, names in _LAZY_MODULES.items()
+    for name in names
+}
+
+
+def __getattr__(name):
+    if name in _LAZY_ATTRS:
+        module = import_module(_LAZY_ATTRS[name])
+        value = getattr(module, name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__))

--- a/rllm/llm/__init__.py
+++ b/rllm/llm/__init__.py
@@ -1,5 +1,6 @@
-from importlib import import_module
 from typing import TYPE_CHECKING
+
+from rllm.utils.lazy_imports import define_lazy_imports
 
 
 if TYPE_CHECKING:
@@ -55,27 +56,8 @@ _LAZY_MODULES = {
     ),
 }
 
-__all__ = [
-    name
-    for names in _LAZY_MODULES.values()
-    for name in names
-]
-
-_LAZY_ATTRS = {
-    name: module_name
-    for module_name, names in _LAZY_MODULES.items()
-    for name in names
-}
-
-
-def __getattr__(name):
-    if name in _LAZY_ATTRS:
-        module = import_module(_LAZY_ATTRS[name])
-        value = getattr(module, name)
-        globals()[name] = value
-        return value
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-
-def __dir__():
-    return sorted(set(globals()) | set(__all__))
+__all__, __getattr__, __dir__ = define_lazy_imports(
+    __name__,
+    globals(),
+    _LAZY_MODULES,
+)

--- a/rllm/llm/__init__.py
+++ b/rllm/llm/__init__.py
@@ -1,26 +1,81 @@
-from .predictor import Predictor
-from .enhancer import Enhancer
-from .prompt.base import PromptTemplate, ChatPromptTemplate
-from .llm_module.langchain_llm import LangChainLLM
-from .llm_module.retrieval.retriever import SingleTableRetriever
-from .llm_module.retrieval.retrieval_llm import LLMWithRetriever
-from .llm_module.featllm.feat_engineer import FeatLLMEngineer
-from .llm_module.featllm.feat_llm import FeatLLM
-from .llm_module.finetune.finetuner import FinetuneConfig, Seq2SeqFinetuner
-from .parser.base import BaseOutputParser
+from importlib import import_module
+from typing import TYPE_CHECKING
 
+
+if TYPE_CHECKING:
+    from rllm.llm.predictor import Predictor
+    from rllm.llm.enhancer import Enhancer
+    from rllm.llm.prompt.base import (
+        PromptTemplate,
+        ChatPromptTemplate,
+    )
+    from rllm.llm.llm_module.langchain_llm import LangChainLLM
+    from rllm.llm.llm_module.retrieval.retriever import SingleTableRetriever
+    from rllm.llm.llm_module.retrieval.retrieval_llm import LLMWithRetriever
+    from rllm.llm.llm_module.featllm.feat_engineer import FeatLLMEngineer
+    from rllm.llm.llm_module.featllm.feat_llm import FeatLLM
+    from rllm.llm.llm_module.finetune.finetuner import (
+        FinetuneConfig,
+        Seq2SeqFinetuner,
+    )
+    from rllm.llm.parser.base import BaseOutputParser
+
+_LAZY_MODULES = {
+    "rllm.llm.predictor": (
+        "Predictor",
+    ),
+    "rllm.llm.enhancer": (
+        "Enhancer",
+    ),
+    "rllm.llm.prompt.base": (
+        "PromptTemplate",
+        "ChatPromptTemplate",
+    ),
+    "rllm.llm.llm_module.langchain_llm": (
+        "LangChainLLM",
+    ),
+    "rllm.llm.llm_module.retrieval.retriever": (
+        "SingleTableRetriever",
+    ),
+    "rllm.llm.llm_module.retrieval.retrieval_llm": (
+        "LLMWithRetriever",
+    ),
+    "rllm.llm.llm_module.featllm.feat_engineer": (
+        "FeatLLMEngineer",
+    ),
+    "rllm.llm.llm_module.featllm.feat_llm": (
+        "FeatLLM",
+    ),
+    "rllm.llm.llm_module.finetune.finetuner": (
+        "FinetuneConfig",
+        "Seq2SeqFinetuner",
+    ),
+    "rllm.llm.parser.base": (
+        "BaseOutputParser",
+    ),
+}
 
 __all__ = [
-    "Predictor",
-    "Enhancer",
-    "PromptTemplate",
-    "ChatPromptTemplate",
-    "LangChainLLM",
-    "SingleTableRetriever",
-    "LLMWithRetriever",
-    "FeatLLMEngineer",
-    "FeatLLM",
-    "FinetuneConfig",
-    "Seq2SeqFinetuner",
-    "BaseOutputParser",
+    name
+    for names in _LAZY_MODULES.values()
+    for name in names
 ]
+
+_LAZY_ATTRS = {
+    name: module_name
+    for module_name, names in _LAZY_MODULES.items()
+    for name in names
+}
+
+
+def __getattr__(name):
+    if name in _LAZY_ATTRS:
+        module = import_module(_LAZY_ATTRS[name])
+        value = getattr(module, name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__))

--- a/rllm/nn/conv/graph_conv/__init__.py
+++ b/rllm/nn/conv/graph_conv/__init__.py
@@ -1,50 +1,95 @@
-from .message_passing import MessagePassing
-from .gat_conv import GATConv
-from .gcn_conv import GCNConv
-from .han_conv import HANConv
-from .hgt_conv import HGTConv
-from .sage_conv import SAGEConv
-from .lgc_conv import LGCConv
-from .transformer_conv import GTransformerConv
-from .relgnn_conv import RelGNNConv
+from importlib import import_module
+from typing import TYPE_CHECKING
 
-from .aggrs import (
-    Aggregator,
-    MeanAggregator,
-    MaxAggregator,
-    MinAggregator,
-    SumAggregator,
-    AddAggregator,
-    ProdAggregator,
-    GCNAggregator,
-    MaxPoolAggregator,
-    MeanPoolAggregator,
-    LSTMAggregator)
 
+if TYPE_CHECKING:
+    from rllm.nn.conv.graph_conv.message_passing import MessagePassing
+    from rllm.nn.conv.graph_conv.gat_conv import GATConv
+    from rllm.nn.conv.graph_conv.gcn_conv import GCNConv
+    from rllm.nn.conv.graph_conv.han_conv import HANConv
+    from rllm.nn.conv.graph_conv.hgt_conv import HGTConv
+    from rllm.nn.conv.graph_conv.sage_conv import SAGEConv
+    from rllm.nn.conv.graph_conv.lgc_conv import LGCConv
+    from rllm.nn.conv.graph_conv.transformer_conv import GTransformerConv
+    from rllm.nn.conv.graph_conv.relgnn_conv import RelGNNConv
+    from rllm.nn.conv.graph_conv.aggrs import (
+        Aggregator,
+        MeanAggregator,
+        MaxAggregator,
+        MinAggregator,
+        SumAggregator,
+        AddAggregator,
+        ProdAggregator,
+        GCNAggregator,
+        MaxPoolAggregator,
+        MeanPoolAggregator,
+        LSTMAggregator,
+    )
+
+_LAZY_MODULES = {
+    "rllm.nn.conv.graph_conv.message_passing": (
+        "MessagePassing",
+    ),
+    "rllm.nn.conv.graph_conv.gat_conv": (
+        "GATConv",
+    ),
+    "rllm.nn.conv.graph_conv.gcn_conv": (
+        "GCNConv",
+    ),
+    "rllm.nn.conv.graph_conv.han_conv": (
+        "HANConv",
+    ),
+    "rllm.nn.conv.graph_conv.hgt_conv": (
+        "HGTConv",
+    ),
+    "rllm.nn.conv.graph_conv.sage_conv": (
+        "SAGEConv",
+    ),
+    "rllm.nn.conv.graph_conv.lgc_conv": (
+        "LGCConv",
+    ),
+    "rllm.nn.conv.graph_conv.transformer_conv": (
+        "GTransformerConv",
+    ),
+    "rllm.nn.conv.graph_conv.relgnn_conv": (
+        "RelGNNConv",
+    ),
+    "rllm.nn.conv.graph_conv.aggrs": (
+        "Aggregator",
+        "MeanAggregator",
+        "MaxAggregator",
+        "MinAggregator",
+        "SumAggregator",
+        "AddAggregator",
+        "ProdAggregator",
+        "GCNAggregator",
+        "MaxPoolAggregator",
+        "MeanPoolAggregator",
+        "LSTMAggregator",
+    ),
+}
 
 __all__ = [
-    "MessagePassing",
-
-    # Graph Convs
-    "GATConv",
-    "GCNConv",
-    "HANConv",
-    "HGTConv",
-    "SAGEConv",
-    "LGCConv",
-    "GTransformerConv",
-    "RelGNNConv",
-
-    # Aggregators
-    "Aggregator",
-    "MeanAggregator",
-    "MaxAggregator",
-    "MinAggregator",
-    "SumAggregator",
-    "AddAggregator",
-    "ProdAggregator",
-    "GCNAggregator",
-    "MaxPoolAggregator",
-    "MeanPoolAggregator",
-    "LSTMAggregator",
+    name
+    for names in _LAZY_MODULES.values()
+    for name in names
 ]
+
+_LAZY_ATTRS = {
+    name: module_name
+    for module_name, names in _LAZY_MODULES.items()
+    for name in names
+}
+
+
+def __getattr__(name):
+    if name in _LAZY_ATTRS:
+        module = import_module(_LAZY_ATTRS[name])
+        value = getattr(module, name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__))

--- a/rllm/nn/conv/graph_conv/__init__.py
+++ b/rllm/nn/conv/graph_conv/__init__.py
@@ -1,5 +1,6 @@
-from importlib import import_module
 from typing import TYPE_CHECKING
+
+from rllm.utils.lazy_imports import define_lazy_imports
 
 
 if TYPE_CHECKING:
@@ -69,27 +70,8 @@ _LAZY_MODULES = {
     ),
 }
 
-__all__ = [
-    name
-    for names in _LAZY_MODULES.values()
-    for name in names
-]
-
-_LAZY_ATTRS = {
-    name: module_name
-    for module_name, names in _LAZY_MODULES.items()
-    for name in names
-}
-
-
-def __getattr__(name):
-    if name in _LAZY_ATTRS:
-        module = import_module(_LAZY_ATTRS[name])
-        value = getattr(module, name)
-        globals()[name] = value
-        return value
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-
-def __dir__():
-    return sorted(set(globals()) | set(__all__))
+__all__, __getattr__, __dir__ = define_lazy_imports(
+    __name__,
+    globals(),
+    _LAZY_MODULES,
+)

--- a/rllm/nn/conv/table_conv/__init__.py
+++ b/rllm/nn/conv/table_conv/__init__.py
@@ -1,17 +1,61 @@
-from .ft_transformer_conv import FTTransformerConv
-from .tab_transformer_conv import TabTransformerConv
-from .excelformer_conv import ExcelFormerConv
-from .trompt_conv import TromptConv
-from .saint_conv import SAINTConv
-from .transtab_conv import TransTabConv
-from .resnet_conv import ResNetConv
+from importlib import import_module
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from rllm.nn.conv.table_conv.ft_transformer_conv import FTTransformerConv
+    from rllm.nn.conv.table_conv.tab_transformer_conv import TabTransformerConv
+    from rllm.nn.conv.table_conv.excelformer_conv import ExcelFormerConv
+    from rllm.nn.conv.table_conv.trompt_conv import TromptConv
+    from rllm.nn.conv.table_conv.saint_conv import SAINTConv
+    from rllm.nn.conv.table_conv.transtab_conv import TransTabConv
+    from rllm.nn.conv.table_conv.resnet_conv import ResNetConv
+
+_LAZY_MODULES = {
+    "rllm.nn.conv.table_conv.ft_transformer_conv": (
+        "FTTransformerConv",
+    ),
+    "rllm.nn.conv.table_conv.tab_transformer_conv": (
+        "TabTransformerConv",
+    ),
+    "rllm.nn.conv.table_conv.excelformer_conv": (
+        "ExcelFormerConv",
+    ),
+    "rllm.nn.conv.table_conv.trompt_conv": (
+        "TromptConv",
+    ),
+    "rllm.nn.conv.table_conv.saint_conv": (
+        "SAINTConv",
+    ),
+    "rllm.nn.conv.table_conv.transtab_conv": (
+        "TransTabConv",
+    ),
+    "rllm.nn.conv.table_conv.resnet_conv": (
+        "ResNetConv",
+    ),
+}
 
 __all__ = [
-    "FTTransformerConv",
-    "TabTransformerConv",
-    "ExcelFormerConv",
-    "TromptConv",
-    "SAINTConv",
-    "TransTabConv",
-    "ResNetConv",
+    name
+    for names in _LAZY_MODULES.values()
+    for name in names
 ]
+
+_LAZY_ATTRS = {
+    name: module_name
+    for module_name, names in _LAZY_MODULES.items()
+    for name in names
+}
+
+
+def __getattr__(name):
+    if name in _LAZY_ATTRS:
+        module = import_module(_LAZY_ATTRS[name])
+        value = getattr(module, name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__))

--- a/rllm/nn/conv/table_conv/__init__.py
+++ b/rllm/nn/conv/table_conv/__init__.py
@@ -1,5 +1,6 @@
-from importlib import import_module
 from typing import TYPE_CHECKING
+
+from rllm.utils.lazy_imports import define_lazy_imports
 
 
 if TYPE_CHECKING:
@@ -35,27 +36,8 @@ _LAZY_MODULES = {
     ),
 }
 
-__all__ = [
-    name
-    for names in _LAZY_MODULES.values()
-    for name in names
-]
-
-_LAZY_ATTRS = {
-    name: module_name
-    for module_name, names in _LAZY_MODULES.items()
-    for name in names
-}
-
-
-def __getattr__(name):
-    if name in _LAZY_ATTRS:
-        module = import_module(_LAZY_ATTRS[name])
-        value = getattr(module, name)
-        globals()[name] = value
-        return value
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-
-def __dir__():
-    return sorted(set(globals()) | set(__all__))
+__all__, __getattr__, __dir__ = define_lazy_imports(
+    __name__,
+    globals(),
+    _LAZY_MODULES,
+)

--- a/rllm/nn/encoder/__init__.py
+++ b/rllm/nn/encoder/__init__.py
@@ -1,21 +1,61 @@
-from .table_pre_encoder import TablePreEncoder
-from .ft_transformer_pre_encoder import FTTransformerPreEncoder
-from .tab_transformer_pre_encoder import TabTransformerPreEncoder
-from .transtab_pre_encoder import TransTabPreEncoder
-from .resnet_pre_encoder import ResNetPreEncoder
-from .trompt_pre_encoder import TromptPreEncoder
-from .heterotemporal_encoder import HeteroTemporalEncoder
+from importlib import import_module
+from typing import TYPE_CHECKING
 
+
+if TYPE_CHECKING:
+    from rllm.nn.encoder.table_pre_encoder import TablePreEncoder
+    from rllm.nn.encoder.ft_transformer_pre_encoder import FTTransformerPreEncoder
+    from rllm.nn.encoder.tab_transformer_pre_encoder import TabTransformerPreEncoder
+    from rllm.nn.encoder.transtab_pre_encoder import TransTabPreEncoder
+    from rllm.nn.encoder.resnet_pre_encoder import ResNetPreEncoder
+    from rllm.nn.encoder.trompt_pre_encoder import TromptPreEncoder
+    from rllm.nn.encoder.heterotemporal_encoder import HeteroTemporalEncoder
+
+_LAZY_MODULES = {
+    "rllm.nn.encoder.table_pre_encoder": (
+        "TablePreEncoder",
+    ),
+    "rllm.nn.encoder.ft_transformer_pre_encoder": (
+        "FTTransformerPreEncoder",
+    ),
+    "rllm.nn.encoder.tab_transformer_pre_encoder": (
+        "TabTransformerPreEncoder",
+    ),
+    "rllm.nn.encoder.transtab_pre_encoder": (
+        "TransTabPreEncoder",
+    ),
+    "rllm.nn.encoder.resnet_pre_encoder": (
+        "ResNetPreEncoder",
+    ),
+    "rllm.nn.encoder.trompt_pre_encoder": (
+        "TromptPreEncoder",
+    ),
+    "rllm.nn.encoder.heterotemporal_encoder": (
+        "HeteroTemporalEncoder",
+    ),
+}
 
 __all__ = [
-    # Base class
-    "TablePreEncoder",
-    # TNN Model PreEncoder
-    "TabTransformerPreEncoder",
-    "FTTransformerPreEncoder",
-    "TransTabPreEncoder",
-    "ResNetPreEncoder",
-    "TromptPreEncoder",
-    # Additional Encoder
-    "HeteroTemporalEncoder",
+    name
+    for names in _LAZY_MODULES.values()
+    for name in names
 ]
+
+_LAZY_ATTRS = {
+    name: module_name
+    for module_name, names in _LAZY_MODULES.items()
+    for name in names
+}
+
+
+def __getattr__(name):
+    if name in _LAZY_ATTRS:
+        module = import_module(_LAZY_ATTRS[name])
+        value = getattr(module, name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__))

--- a/rllm/nn/encoder/__init__.py
+++ b/rllm/nn/encoder/__init__.py
@@ -1,5 +1,6 @@
-from importlib import import_module
 from typing import TYPE_CHECKING
+
+from rllm.utils.lazy_imports import define_lazy_imports
 
 
 if TYPE_CHECKING:
@@ -35,27 +36,8 @@ _LAZY_MODULES = {
     ),
 }
 
-__all__ = [
-    name
-    for names in _LAZY_MODULES.values()
-    for name in names
-]
-
-_LAZY_ATTRS = {
-    name: module_name
-    for module_name, names in _LAZY_MODULES.items()
-    for name in names
-}
-
-
-def __getattr__(name):
-    if name in _LAZY_ATTRS:
-        module = import_module(_LAZY_ATTRS[name])
-        value = getattr(module, name)
-        globals()[name] = value
-        return value
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-
-def __dir__():
-    return sorted(set(globals()) | set(__all__))
+__all__, __getattr__, __dir__ = define_lazy_imports(
+    __name__,
+    globals(),
+    _LAZY_MODULES,
+)

--- a/rllm/nn/encoder/col_encoder/__init__.py
+++ b/rllm/nn/encoder/col_encoder/__init__.py
@@ -1,9 +1,41 @@
-"""Internal column encoder implementations. Not part of public API."""
+from importlib import import_module
+from typing import TYPE_CHECKING
 
-from ._embedding_encoder import EmbeddingEncoder
-from ._linear_encoder import LinearEncoder
+
+if TYPE_CHECKING:
+    from rllm.nn.encoder.col_encoder._embedding_encoder import EmbeddingEncoder
+    from rllm.nn.encoder.col_encoder._linear_encoder import LinearEncoder
+
+_LAZY_MODULES = {
+    "rllm.nn.encoder.col_encoder._embedding_encoder": (
+        "EmbeddingEncoder",
+    ),
+    "rllm.nn.encoder.col_encoder._linear_encoder": (
+        "LinearEncoder",
+    ),
+}
 
 __all__ = [
-    "EmbeddingEncoder",
-    "LinearEncoder",
+    name
+    for names in _LAZY_MODULES.values()
+    for name in names
 ]
+
+_LAZY_ATTRS = {
+    name: module_name
+    for module_name, names in _LAZY_MODULES.items()
+    for name in names
+}
+
+
+def __getattr__(name):
+    if name in _LAZY_ATTRS:
+        module = import_module(_LAZY_ATTRS[name])
+        value = getattr(module, name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__))

--- a/rllm/nn/encoder/col_encoder/__init__.py
+++ b/rllm/nn/encoder/col_encoder/__init__.py
@@ -1,5 +1,6 @@
-from importlib import import_module
 from typing import TYPE_CHECKING
+
+from rllm.utils.lazy_imports import define_lazy_imports
 
 
 if TYPE_CHECKING:
@@ -15,27 +16,8 @@ _LAZY_MODULES = {
     ),
 }
 
-__all__ = [
-    name
-    for names in _LAZY_MODULES.values()
-    for name in names
-]
-
-_LAZY_ATTRS = {
-    name: module_name
-    for module_name, names in _LAZY_MODULES.items()
-    for name in names
-}
-
-
-def __getattr__(name):
-    if name in _LAZY_ATTRS:
-        module = import_module(_LAZY_ATTRS[name])
-        value = getattr(module, name)
-        globals()[name] = value
-        return value
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-
-def __dir__():
-    return sorted(set(globals()) | set(__all__))
+__all__, __getattr__, __dir__ = define_lazy_imports(
+    __name__,
+    globals(),
+    _LAZY_MODULES,
+)

--- a/rllm/nn/loss/__init__.py
+++ b/rllm/nn/loss/__init__.py
@@ -1,10 +1,49 @@
-from .base_loss import BaseLoss
-from .contrastive_loss import ContrastiveLoss
-from .vpcl_loss import SelfSupervisedVPCL, SupervisedVPCL
+from importlib import import_module
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from rllm.nn.loss.base_loss import BaseLoss
+    from rllm.nn.loss.contrastive_loss import ContrastiveLoss
+    from rllm.nn.loss.vpcl_loss import (
+        SelfSupervisedVPCL,
+        SupervisedVPCL,
+    )
+
+_LAZY_MODULES = {
+    "rllm.nn.loss.base_loss": (
+        "BaseLoss",
+    ),
+    "rllm.nn.loss.contrastive_loss": (
+        "ContrastiveLoss",
+    ),
+    "rllm.nn.loss.vpcl_loss": (
+        "SelfSupervisedVPCL",
+        "SupervisedVPCL",
+    ),
+}
 
 __all__ = [
-    "BaseLoss",
-    "ContrastiveLoss",
-    "SelfSupervisedVPCL",
-    "SupervisedVPCL",
+    name
+    for names in _LAZY_MODULES.values()
+    for name in names
 ]
+
+_LAZY_ATTRS = {
+    name: module_name
+    for module_name, names in _LAZY_MODULES.items()
+    for name in names
+}
+
+
+def __getattr__(name):
+    if name in _LAZY_ATTRS:
+        module = import_module(_LAZY_ATTRS[name])
+        value = getattr(module, name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__))

--- a/rllm/nn/loss/__init__.py
+++ b/rllm/nn/loss/__init__.py
@@ -1,5 +1,6 @@
-from importlib import import_module
 from typing import TYPE_CHECKING
+
+from rllm.utils.lazy_imports import define_lazy_imports
 
 
 if TYPE_CHECKING:
@@ -23,27 +24,8 @@ _LAZY_MODULES = {
     ),
 }
 
-__all__ = [
-    name
-    for names in _LAZY_MODULES.values()
-    for name in names
-]
-
-_LAZY_ATTRS = {
-    name: module_name
-    for module_name, names in _LAZY_MODULES.items()
-    for name in names
-}
-
-
-def __getattr__(name):
-    if name in _LAZY_ATTRS:
-        module = import_module(_LAZY_ATTRS[name])
-        value = getattr(module, name)
-        globals()[name] = value
-        return value
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-
-def __dir__():
-    return sorted(set(globals()) | set(__all__))
+__all__, __getattr__, __dir__ = define_lazy_imports(
+    __name__,
+    globals(),
+    _LAZY_MODULES,
+)

--- a/rllm/nn/models/__init__.py
+++ b/rllm/nn/models/__init__.py
@@ -1,23 +1,77 @@
-from .rect import RECT_L
-from .bridge import BRIDGE, TableEncoder, GraphEncoder
-from .transtab import TransTab, TransTabClassifier, TransTabForCL
-from .resnet import TableResNet
-from .heterosage import HeteroSAGE
-from .rdl import RDL
-from .relgnn import RelGNN, RelGNNModel
+from importlib import import_module
+from typing import TYPE_CHECKING
 
+
+if TYPE_CHECKING:
+    from rllm.nn.models.rect import RECT_L
+    from rllm.nn.models.bridge import (
+        BRIDGE,
+        TableEncoder,
+        GraphEncoder,
+    )
+    from rllm.nn.models.transtab import (
+        TransTab,
+        TransTabClassifier,
+        TransTabForCL,
+    )
+    from rllm.nn.models.resnet import TableResNet
+    from rllm.nn.models.heterosage import HeteroSAGE
+    from rllm.nn.models.rdl import RDL
+    from rllm.nn.models.relgnn import (
+        RelGNN,
+        RelGNNModel,
+    )
+
+_LAZY_MODULES = {
+    "rllm.nn.models.rect": (
+        "RECT_L",
+    ),
+    "rllm.nn.models.bridge": (
+        "BRIDGE",
+        "TableEncoder",
+        "GraphEncoder",
+    ),
+    "rllm.nn.models.transtab": (
+        "TransTab",
+        "TransTabClassifier",
+        "TransTabForCL",
+    ),
+    "rllm.nn.models.resnet": (
+        "TableResNet",
+    ),
+    "rllm.nn.models.heterosage": (
+        "HeteroSAGE",
+    ),
+    "rllm.nn.models.rdl": (
+        "RDL",
+    ),
+    "rllm.nn.models.relgnn": (
+        "RelGNN",
+        "RelGNNModel",
+    ),
+}
 
 __all__ = [
-    "RECT_L",
-    "BRIDGE",
-    "TransTab",
-    "TransTabClassifier",
-    "TransTabForCL",
-    "TableResNet",
-    "HeteroSAGE",
-    "RDL",
-    "RelGNN",
-    "RelGNNModel",
-    "TableEncoder",
-    "GraphEncoder",
+    name
+    for names in _LAZY_MODULES.values()
+    for name in names
 ]
+
+_LAZY_ATTRS = {
+    name: module_name
+    for module_name, names in _LAZY_MODULES.items()
+    for name in names
+}
+
+
+def __getattr__(name):
+    if name in _LAZY_ATTRS:
+        module = import_module(_LAZY_ATTRS[name])
+        value = getattr(module, name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__))

--- a/rllm/nn/models/__init__.py
+++ b/rllm/nn/models/__init__.py
@@ -1,5 +1,6 @@
-from importlib import import_module
 from typing import TYPE_CHECKING
+
+from rllm.utils.lazy_imports import define_lazy_imports
 
 
 if TYPE_CHECKING:
@@ -51,27 +52,8 @@ _LAZY_MODULES = {
     ),
 }
 
-__all__ = [
-    name
-    for names in _LAZY_MODULES.values()
-    for name in names
-]
-
-_LAZY_ATTRS = {
-    name: module_name
-    for module_name, names in _LAZY_MODULES.items()
-    for name in names
-}
-
-
-def __getattr__(name):
-    if name in _LAZY_ATTRS:
-        module = import_module(_LAZY_ATTRS[name])
-        value = getattr(module, name)
-        globals()[name] = value
-        return value
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-
-def __dir__():
-    return sorted(set(globals()) | set(__all__))
+__all__, __getattr__, __dir__ = define_lazy_imports(
+    __name__,
+    globals(),
+    _LAZY_MODULES,
+)

--- a/rllm/preprocessing/__init__.py
+++ b/rllm/preprocessing/__init__.py
@@ -1,5 +1,6 @@
-from importlib import import_module
 from typing import TYPE_CHECKING
+
+from rllm.utils.lazy_imports import define_lazy_imports
 
 if TYPE_CHECKING:
     from rllm.preprocessing.fillna import (
@@ -44,21 +45,8 @@ _LAZY_MODULES = {
     "rllm.preprocessing.df_to_tensor": ("df_to_tensor",),
 }
 
-__all__ = [name for names in _LAZY_MODULES.values() for name in names]
-
-_LAZY_ATTRS = {
-    name: module_name for module_name, names in _LAZY_MODULES.items() for name in names
-}
-
-
-def __getattr__(name):
-    if name in _LAZY_ATTRS:
-        module = import_module(_LAZY_ATTRS[name])
-        value = getattr(module, name)
-        globals()[name] = value
-        return value
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-
-def __dir__():
-    return sorted(set(globals()) | set(__all__))
+__all__, __getattr__, __dir__ = define_lazy_imports(
+    __name__,
+    globals(),
+    _LAZY_MODULES,
+)

--- a/rllm/preprocessing/__init__.py
+++ b/rllm/preprocessing/__init__.py
@@ -1,38 +1,64 @@
-from rllm.preprocessing.fillna import FillNAConfig, fillna_by_coltype
-from rllm.preprocessing.text_tokenize import (
-    TokenizerConfig,
-    process_tokenized_column,
-    tokenize_strings,
-    standardize_tokenizer_output,
-    tokenize_merged_cols,
-    save_column_name_tokens,
-)
-from rllm.preprocessing.word_embedding import (
-    TextEmbedderConfig,
-    embed_text_column,
-)
-from rllm.preprocessing.data_clean import to_numeric_by_column
-from rllm.preprocessing.timestamp import TimestampPreprocessor
-from rllm.preprocessing.df_to_tensor import df_to_tensor
+from importlib import import_module
+from typing import TYPE_CHECKING
 
-__all__ = [
-    # df to tensor
-    "df_to_tensor",
-    # text tokenize
-    "TokenizerConfig",
-    "process_tokenized_column",
-    "tokenize_strings",
-    "standardize_tokenizer_output",
-    "tokenize_merged_cols",
-    "save_column_name_tokens",
-    # word embedding
-    "TextEmbedderConfig",
-    "embed_text_column",
-    # timestamp
-    "TimestampPreprocessor",
-    # data clean
-    "to_numeric_by_column",
-    # fillna
-    "FillNAConfig",
-    "fillna_by_coltype",
-]
+if TYPE_CHECKING:
+    from rllm.preprocessing.fillna import (
+        FillNAConfig,
+        fillna_by_coltype,
+    )
+    from rllm.preprocessing.text_tokenize import (
+        TokenizerConfig,
+        process_tokenized_column,
+        tokenize_strings,
+        standardize_tokenizer_output,
+        tokenize_merged_cols,
+        save_column_name_tokens,
+    )
+    from rllm.preprocessing.word_embedding import (
+        TextEmbedderConfig,
+        embed_text_column,
+    )
+    from rllm.preprocessing.data_clean import to_numeric_by_column
+    from rllm.preprocessing.timestamp import TimestampPreprocessor
+    from rllm.preprocessing.df_to_tensor import df_to_tensor
+
+_LAZY_MODULES = {
+    "rllm.preprocessing.fillna": (
+        "FillNAConfig",
+        "fillna_by_coltype",
+    ),
+    "rllm.preprocessing.text_tokenize": (
+        "TokenizerConfig",
+        "process_tokenized_column",
+        "tokenize_strings",
+        "standardize_tokenizer_output",
+        "tokenize_merged_cols",
+        "save_column_name_tokens",
+    ),
+    "rllm.preprocessing.word_embedding": (
+        "TextEmbedderConfig",
+        "embed_text_column",
+    ),
+    "rllm.preprocessing.data_clean": ("to_numeric_by_column",),
+    "rllm.preprocessing.timestamp": ("TimestampPreprocessor",),
+    "rllm.preprocessing.df_to_tensor": ("df_to_tensor",),
+}
+
+__all__ = [name for names in _LAZY_MODULES.values() for name in names]
+
+_LAZY_ATTRS = {
+    name: module_name for module_name, names in _LAZY_MODULES.items() for name in names
+}
+
+
+def __getattr__(name):
+    if name in _LAZY_ATTRS:
+        module = import_module(_LAZY_ATTRS[name])
+        value = getattr(module, name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__))

--- a/rllm/transforms/graph_transforms/__init__.py
+++ b/rllm/transforms/graph_transforms/__init__.py
@@ -1,5 +1,6 @@
-from importlib import import_module
 from typing import TYPE_CHECKING
+
+from rllm.utils.lazy_imports import define_lazy_imports
 
 
 if TYPE_CHECKING:
@@ -55,27 +56,8 @@ _LAZY_MODULES = {
     ),
 }
 
-__all__ = [
-    name
-    for names in _LAZY_MODULES.values()
-    for name in names
-]
-
-_LAZY_ATTRS = {
-    name: module_name
-    for module_name, names in _LAZY_MODULES.items()
-    for name in names
-}
-
-
-def __getattr__(name):
-    if name in _LAZY_ATTRS:
-        module = import_module(_LAZY_ATTRS[name])
-        value = getattr(module, name)
-        globals()[name] = value
-        return value
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-
-def __dir__():
-    return sorted(set(globals()) | set(__all__))
+__all__, __getattr__, __dir__ = define_lazy_imports(
+    __name__,
+    globals(),
+    _LAZY_MODULES,
+)

--- a/rllm/transforms/graph_transforms/__init__.py
+++ b/rllm/transforms/graph_transforms/__init__.py
@@ -1,30 +1,81 @@
-from .node_edge_transform import EdgeTransform, NodeTransform  # noqa
-from .add_remaining_self_loops import AddRemainingSelfLoops  # noqa
-from .remove_self_loops import RemoveSelfLoops  # noqa
-from .knn_graph import KNNGraph  # noqa
-from .gcn_norm import GCNNorm  # noqa
-from .gdc import GDC
-from .graph_transform import GraphTransform  # noqa
-from .gcn_transform import GCNTransform  # noqa
-from .rect_transform import RECTTransform  # noqa
-from .normalize_features import NormalizeFeatures  # noqa
-from .svd_feature_reduction import SVDFeatureReduction  # noqa
+from importlib import import_module
+from typing import TYPE_CHECKING
 
+
+if TYPE_CHECKING:
+    from rllm.transforms.graph_transforms.node_edge_transform import (
+        NodeTransform,
+        EdgeTransform,
+    )
+    from rllm.transforms.graph_transforms.add_remaining_self_loops import AddRemainingSelfLoops
+    from rllm.transforms.graph_transforms.remove_self_loops import RemoveSelfLoops
+    from rllm.transforms.graph_transforms.knn_graph import KNNGraph
+    from rllm.transforms.graph_transforms.gcn_norm import GCNNorm
+    from rllm.transforms.graph_transforms.gdc import GDC
+    from rllm.transforms.graph_transforms.graph_transform import GraphTransform
+    from rllm.transforms.graph_transforms.gcn_transform import GCNTransform
+    from rllm.transforms.graph_transforms.rect_transform import RECTTransform
+    from rllm.transforms.graph_transforms.normalize_features import NormalizeFeatures
+    from rllm.transforms.graph_transforms.svd_feature_reduction import SVDFeatureReduction
+
+_LAZY_MODULES = {
+    "rllm.transforms.graph_transforms.node_edge_transform": (
+        "NodeTransform",
+        "EdgeTransform",
+    ),
+    "rllm.transforms.graph_transforms.add_remaining_self_loops": (
+        "AddRemainingSelfLoops",
+    ),
+    "rllm.transforms.graph_transforms.remove_self_loops": (
+        "RemoveSelfLoops",
+    ),
+    "rllm.transforms.graph_transforms.knn_graph": (
+        "KNNGraph",
+    ),
+    "rllm.transforms.graph_transforms.gcn_norm": (
+        "GCNNorm",
+    ),
+    "rllm.transforms.graph_transforms.gdc": (
+        "GDC",
+    ),
+    "rllm.transforms.graph_transforms.graph_transform": (
+        "GraphTransform",
+    ),
+    "rllm.transforms.graph_transforms.gcn_transform": (
+        "GCNTransform",
+    ),
+    "rllm.transforms.graph_transforms.rect_transform": (
+        "RECTTransform",
+    ),
+    "rllm.transforms.graph_transforms.normalize_features": (
+        "NormalizeFeatures",
+    ),
+    "rllm.transforms.graph_transforms.svd_feature_reduction": (
+        "SVDFeatureReduction",
+    ),
+}
 
 __all__ = [
-    # node transforms
-    "NodeTransform",
-    "NormalizeFeatures",
-    "SVDFeatureReduction",
-    # edge transforms
-    "EdgeTransform",
-    "AddRemainingSelfLoops",
-    "GCNNorm",
-    "GDC",
-    "KNNGraph",
-    "RemoveSelfLoops",
-    # graph transforms
-    "GraphTransform",
-    "GCNTransform",
-    "RECTTransform",
+    name
+    for names in _LAZY_MODULES.values()
+    for name in names
 ]
+
+_LAZY_ATTRS = {
+    name: module_name
+    for module_name, names in _LAZY_MODULES.items()
+    for name in names
+}
+
+
+def __getattr__(name):
+    if name in _LAZY_ATTRS:
+        module = import_module(_LAZY_ATTRS[name])
+        value = getattr(module, name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__))

--- a/rllm/transforms/graph_transforms/functional/__init__.py
+++ b/rllm/transforms/graph_transforms/functional/__init__.py
@@ -1,16 +1,57 @@
-from .add_remaining_self_loops import add_remaining_self_loops  # noqa
-from .remove_self_loops import remove_self_loops  # noqa
-from .knn_graph import knn_graph  # noqa
-from .symmetric_norm import symmetric_norm  # noqa
-from .normalize_features import normalize_features  # noqa
-from .svd_feature_reduction import svd_feature_reduction  # noqa
+from importlib import import_module
+from typing import TYPE_CHECKING
 
+
+if TYPE_CHECKING:
+    from rllm.transforms.graph_transforms.functional.add_remaining_self_loops import add_remaining_self_loops
+    from rllm.transforms.graph_transforms.functional.remove_self_loops import remove_self_loops
+    from rllm.transforms.graph_transforms.functional.knn_graph import knn_graph
+    from rllm.transforms.graph_transforms.functional.symmetric_norm import symmetric_norm
+    from rllm.transforms.graph_transforms.functional.normalize_features import normalize_features
+    from rllm.transforms.graph_transforms.functional.svd_feature_reduction import svd_feature_reduction
+
+_LAZY_MODULES = {
+    "rllm.transforms.graph_transforms.functional.add_remaining_self_loops": (
+        "add_remaining_self_loops",
+    ),
+    "rllm.transforms.graph_transforms.functional.remove_self_loops": (
+        "remove_self_loops",
+    ),
+    "rllm.transforms.graph_transforms.functional.knn_graph": (
+        "knn_graph",
+    ),
+    "rllm.transforms.graph_transforms.functional.symmetric_norm": (
+        "symmetric_norm",
+    ),
+    "rllm.transforms.graph_transforms.functional.normalize_features": (
+        "normalize_features",
+    ),
+    "rllm.transforms.graph_transforms.functional.svd_feature_reduction": (
+        "svd_feature_reduction",
+    ),
+}
 
 __all__ = [
-    "add_remaining_self_loops",
-    "remove_self_loops",
-    "knn_graph",
-    "symmetric_norm",
-    "normalize_features",
-    "svd_feature_reduction",
+    name
+    for names in _LAZY_MODULES.values()
+    for name in names
 ]
+
+_LAZY_ATTRS = {
+    name: module_name
+    for module_name, names in _LAZY_MODULES.items()
+    for name in names
+}
+
+
+def __getattr__(name):
+    if name in _LAZY_ATTRS:
+        module = import_module(_LAZY_ATTRS[name])
+        value = getattr(module, name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__))

--- a/rllm/transforms/graph_transforms/functional/__init__.py
+++ b/rllm/transforms/graph_transforms/functional/__init__.py
@@ -1,5 +1,6 @@
-from importlib import import_module
 from typing import TYPE_CHECKING
+
+from rllm.utils.lazy_imports import define_lazy_imports
 
 
 if TYPE_CHECKING:
@@ -31,27 +32,8 @@ _LAZY_MODULES = {
     ),
 }
 
-__all__ = [
-    name
-    for names in _LAZY_MODULES.values()
-    for name in names
-]
-
-_LAZY_ATTRS = {
-    name: module_name
-    for module_name, names in _LAZY_MODULES.items()
-    for name in names
-}
-
-
-def __getattr__(name):
-    if name in _LAZY_ATTRS:
-        module = import_module(_LAZY_ATTRS[name])
-        value = getattr(module, name)
-        globals()[name] = value
-        return value
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-
-def __dir__():
-    return sorted(set(globals()) | set(__all__))
+__all__, __getattr__, __dir__ = define_lazy_imports(
+    __name__,
+    globals(),
+    _LAZY_MODULES,
+)

--- a/rllm/transforms/table_transforms/__init__.py
+++ b/rllm/transforms/table_transforms/__init__.py
@@ -1,5 +1,6 @@
-from importlib import import_module
 from typing import TYPE_CHECKING
+
+from rllm.utils.lazy_imports import define_lazy_imports
 
 
 if TYPE_CHECKING:
@@ -35,27 +36,8 @@ _LAZY_MODULES = {
     ),
 }
 
-__all__ = [
-    name
-    for names in _LAZY_MODULES.values()
-    for name in names
-]
-
-_LAZY_ATTRS = {
-    name: module_name
-    for module_name, names in _LAZY_MODULES.items()
-    for name in names
-}
-
-
-def __getattr__(name):
-    if name in _LAZY_ATTRS:
-        module = import_module(_LAZY_ATTRS[name])
-        value = getattr(module, name)
-        globals()[name] = value
-        return value
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-
-def __dir__():
-    return sorted(set(globals()) | set(__all__))
+__all__, __getattr__, __dir__ = define_lazy_imports(
+    __name__,
+    globals(),
+    _LAZY_MODULES,
+)

--- a/rllm/transforms/table_transforms/__init__.py
+++ b/rllm/transforms/table_transforms/__init__.py
@@ -1,17 +1,61 @@
-from .col_transform import ColTransform
-from .col_normalize import ColNormalize
-from .one_hot_transform import OneHotTransform
-from .stack_numerical import StackNumerical
-from .table_transform import TableTransform
-from .tab_transformer_transform import TabTransformerTransform
-from .default_table_transform import DefaultTableTransform
+from importlib import import_module
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from rllm.transforms.table_transforms.col_transform import ColTransform
+    from rllm.transforms.table_transforms.col_normalize import ColNormalize
+    from rllm.transforms.table_transforms.one_hot_transform import OneHotTransform
+    from rllm.transforms.table_transforms.stack_numerical import StackNumerical
+    from rllm.transforms.table_transforms.table_transform import TableTransform
+    from rllm.transforms.table_transforms.tab_transformer_transform import TabTransformerTransform
+    from rllm.transforms.table_transforms.default_table_transform import DefaultTableTransform
+
+_LAZY_MODULES = {
+    "rllm.transforms.table_transforms.col_transform": (
+        "ColTransform",
+    ),
+    "rllm.transforms.table_transforms.col_normalize": (
+        "ColNormalize",
+    ),
+    "rllm.transforms.table_transforms.one_hot_transform": (
+        "OneHotTransform",
+    ),
+    "rllm.transforms.table_transforms.stack_numerical": (
+        "StackNumerical",
+    ),
+    "rllm.transforms.table_transforms.table_transform": (
+        "TableTransform",
+    ),
+    "rllm.transforms.table_transforms.tab_transformer_transform": (
+        "TabTransformerTransform",
+    ),
+    "rllm.transforms.table_transforms.default_table_transform": (
+        "DefaultTableTransform",
+    ),
+}
 
 __all__ = [
-    "ColTransform",
-    "ColNormalize",
-    "OneHotTransform",
-    "StackNumerical",
-    "TableTransform",
-    "TabTransformerTransform",
-    "DefaultTableTransform",
+    name
+    for names in _LAZY_MODULES.values()
+    for name in names
 ]
+
+_LAZY_ATTRS = {
+    name: module_name
+    for module_name, names in _LAZY_MODULES.items()
+    for name in names
+}
+
+
+def __getattr__(name):
+    if name in _LAZY_ATTRS:
+        module = import_module(_LAZY_ATTRS[name])
+        value = getattr(module, name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__))

--- a/rllm/transforms/utils/__init__.py
+++ b/rllm/transforms/utils/__init__.py
@@ -1,5 +1,6 @@
-from importlib import import_module
 from typing import TYPE_CHECKING
+
+from rllm.utils.lazy_imports import define_lazy_imports
 
 
 if TYPE_CHECKING:
@@ -15,27 +16,8 @@ _LAZY_MODULES = {
     ),
 }
 
-__all__ = [
-    name
-    for names in _LAZY_MODULES.values()
-    for name in names
-]
-
-_LAZY_ATTRS = {
-    name: module_name
-    for module_name, names in _LAZY_MODULES.items()
-    for name in names
-}
-
-
-def __getattr__(name):
-    if name in _LAZY_ATTRS:
-        module = import_module(_LAZY_ATTRS[name])
-        value = getattr(module, name)
-        globals()[name] = value
-        return value
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-
-def __dir__():
-    return sorted(set(globals()) | set(__all__))
+__all__, __getattr__, __dir__ = define_lazy_imports(
+    __name__,
+    globals(),
+    _LAZY_MODULES,
+)

--- a/rllm/transforms/utils/__init__.py
+++ b/rllm/transforms/utils/__init__.py
@@ -1,7 +1,41 @@
-from .base_transform import BaseTransform
-from .remove_training_classes import RemoveTrainingClasses
+from importlib import import_module
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from rllm.transforms.utils.base_transform import BaseTransform
+    from rllm.transforms.utils.remove_training_classes import RemoveTrainingClasses
+
+_LAZY_MODULES = {
+    "rllm.transforms.utils.base_transform": (
+        "BaseTransform",
+    ),
+    "rllm.transforms.utils.remove_training_classes": (
+        "RemoveTrainingClasses",
+    ),
+}
 
 __all__ = [
-    "BaseTransform",
-    "RemoveTrainingClasses",
+    name
+    for names in _LAZY_MODULES.values()
+    for name in names
 ]
+
+_LAZY_ATTRS = {
+    name: module_name
+    for module_name, names in _LAZY_MODULES.items()
+    for name in names
+}
+
+
+def __getattr__(name):
+    if name in _LAZY_ATTRS:
+        module = import_module(_LAZY_ATTRS[name])
+        value = getattr(module, name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__))

--- a/rllm/transforms/utils/functional/__init__.py
+++ b/rllm/transforms/utils/functional/__init__.py
@@ -1,5 +1,6 @@
-from importlib import import_module
 from typing import TYPE_CHECKING
+
+from rllm.utils.lazy_imports import define_lazy_imports
 
 
 if TYPE_CHECKING:
@@ -11,27 +12,8 @@ _LAZY_MODULES = {
     ),
 }
 
-__all__ = [
-    name
-    for names in _LAZY_MODULES.values()
-    for name in names
-]
-
-_LAZY_ATTRS = {
-    name: module_name
-    for module_name, names in _LAZY_MODULES.items()
-    for name in names
-}
-
-
-def __getattr__(name):
-    if name in _LAZY_ATTRS:
-        module = import_module(_LAZY_ATTRS[name])
-        value = getattr(module, name)
-        globals()[name] = value
-        return value
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-
-def __dir__():
-    return sorted(set(globals()) | set(__all__))
+__all__, __getattr__, __dir__ = define_lazy_imports(
+    __name__,
+    globals(),
+    _LAZY_MODULES,
+)

--- a/rllm/transforms/utils/functional/__init__.py
+++ b/rllm/transforms/utils/functional/__init__.py
@@ -1,3 +1,37 @@
-from .remove_training_classes import remove_training_classes  # noqa
+from importlib import import_module
+from typing import TYPE_CHECKING
 
-__all__ = ["remove_training_classes"]
+
+if TYPE_CHECKING:
+    from rllm.transforms.utils.functional.remove_training_classes import remove_training_classes
+
+_LAZY_MODULES = {
+    "rllm.transforms.utils.functional.remove_training_classes": (
+        "remove_training_classes",
+    ),
+}
+
+__all__ = [
+    name
+    for names in _LAZY_MODULES.values()
+    for name in names
+]
+
+_LAZY_ATTRS = {
+    name: module_name
+    for module_name, names in _LAZY_MODULES.items()
+    for name in names
+}
+
+
+def __getattr__(name):
+    if name in _LAZY_ATTRS:
+        module = import_module(_LAZY_ATTRS[name])
+        value = getattr(module, name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__))

--- a/rllm/utils/__init__.py
+++ b/rllm/utils/__init__.py
@@ -1,49 +1,103 @@
-from .download import download_url, download_google_url
-from .extract import extract_zip
-from .sparse import (
-    sparse_mx_to_torch_sparse_tensor,
-    is_torch_sparse_tensor,
-    get_indices,
-    set_values,
-)
-from .undirected import is_undirected, to_undirected
-from .seg_reduce import (
-    seg_sum,
-    seg_softmax,
-    seg_softmax_,
-)
+from importlib import import_module
+from typing import TYPE_CHECKING
 
-from .graph_utils import (
-    adj_to_edge_index,
-    sort_edge_index,
-    index_to_ptr,
-    _to_csc
-)
 
-from ._sort import lexsort
-from ._remap import remap_keys
-from ._mixin import CastMixin
-from .atomic_routes import get_atomic_routes
+if TYPE_CHECKING:
+    from rllm.utils.download import (
+        download_url,
+        download_google_url,
+    )
+    from rllm.utils.extract import extract_zip
+    from rllm.utils.sparse import (
+        sparse_mx_to_torch_sparse_tensor,
+        is_torch_sparse_tensor,
+        get_indices,
+        set_values,
+    )
+    from rllm.utils.undirected import (
+        is_undirected,
+        to_undirected,
+    )
+    from rllm.utils.seg_reduce import (
+        seg_sum,
+        seg_softmax,
+        seg_softmax_,
+    )
+    from rllm.utils.graph_utils import (
+        adj_to_edge_index,
+        sort_edge_index,
+        index_to_ptr,
+        _to_csc,
+    )
+    from rllm.utils._sort import lexsort
+    from rllm.utils._remap import remap_keys
+    from rllm.utils._mixin import CastMixin
+    from rllm.utils.atomic_routes import get_atomic_routes
+
+_LAZY_MODULES = {
+    "rllm.utils.download": (
+        "download_url",
+        "download_google_url",
+    ),
+    "rllm.utils.extract": (
+        "extract_zip",
+    ),
+    "rllm.utils.sparse": (
+        "sparse_mx_to_torch_sparse_tensor",
+        "is_torch_sparse_tensor",
+        "get_indices",
+        "set_values",
+    ),
+    "rllm.utils.undirected": (
+        "is_undirected",
+        "to_undirected",
+    ),
+    "rllm.utils.seg_reduce": (
+        "seg_sum",
+        "seg_softmax",
+        "seg_softmax_",
+    ),
+    "rllm.utils.graph_utils": (
+        "adj_to_edge_index",
+        "sort_edge_index",
+        "index_to_ptr",
+        "_to_csc",
+    ),
+    "rllm.utils._sort": (
+        "lexsort",
+    ),
+    "rllm.utils._remap": (
+        "remap_keys",
+    ),
+    "rllm.utils._mixin": (
+        "CastMixin",
+    ),
+    "rllm.utils.atomic_routes": (
+        "get_atomic_routes",
+    ),
+}
 
 __all__ = [
-    "download_url",
-    "download_google_url",
-    "extract_zip",
-    "sparse_mx_to_torch_sparse_tensor",
-    "is_torch_sparse_tensor",
-    "get_indices",
-    "is_undirected",
-    "to_undirected",
-    "set_values",
-    "adj_to_edge_index",
-    "_to_csc",
-    "seg_sum",
-    "seg_softmax",
-    "seg_softmax_",
-    "sort_edge_index",
-    "index_to_ptr",
-    "lexsort",
-    "remap_keys",
-    "CastMixin",
-    "get_atomic_routes",
+    name
+    for names in _LAZY_MODULES.values()
+    for name in names
 ]
+
+_LAZY_ATTRS = {
+    name: module_name
+    for module_name, names in _LAZY_MODULES.items()
+    for name in names
+}
+
+
+def __getattr__(name):
+    if name in _LAZY_ATTRS:
+        module = import_module(_LAZY_ATTRS[name])
+        value = getattr(module, name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
+def __dir__():
+    return sorted(set(globals()) | set(__all__))

--- a/rllm/utils/__init__.py
+++ b/rllm/utils/__init__.py
@@ -1,5 +1,6 @@
-from importlib import import_module
 from typing import TYPE_CHECKING
+
+from rllm.utils.lazy_imports import define_lazy_imports
 
 
 if TYPE_CHECKING:
@@ -77,27 +78,8 @@ _LAZY_MODULES = {
     ),
 }
 
-__all__ = [
-    name
-    for names in _LAZY_MODULES.values()
-    for name in names
-]
-
-_LAZY_ATTRS = {
-    name: module_name
-    for module_name, names in _LAZY_MODULES.items()
-    for name in names
-}
-
-
-def __getattr__(name):
-    if name in _LAZY_ATTRS:
-        module = import_module(_LAZY_ATTRS[name])
-        value = getattr(module, name)
-        globals()[name] = value
-        return value
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
-
-def __dir__():
-    return sorted(set(globals()) | set(__all__))
+__all__, __getattr__, __dir__ = define_lazy_imports(
+    __name__,
+    globals(),
+    _LAZY_MODULES,
+)

--- a/rllm/utils/lazy_imports.py
+++ b/rllm/utils/lazy_imports.py
@@ -1,0 +1,44 @@
+from importlib import import_module
+from typing import Any, Callable, Dict, List, Mapping, Optional, Sequence, Tuple
+
+
+def define_lazy_imports(
+    module_name: str,
+    module_globals: Dict[str, Any],
+    lazy_modules: Mapping[str, Sequence[str]],
+    lazy_submodules: Optional[Mapping[str, str]] = None,
+) -> Tuple[List[str], Callable[[str], Any], Callable[[], List[str]]]:
+    all_names = [
+        name
+        for names in lazy_modules.values()
+        for name in names
+    ]
+    lazy_attrs = {
+        name: import_path
+        for import_path, names in lazy_modules.items()
+        for name in names
+    }
+    submodules = dict(lazy_submodules or {})
+    prefix = f"{module_name}."
+    for import_path in lazy_modules:
+        if not import_path.startswith(prefix):
+            continue
+        submodule_name = import_path[len(prefix):].split(".", 1)[0]
+        submodules.setdefault(submodule_name, f"{module_name}.{submodule_name}")
+
+    def __getattr__(name: str) -> Any:
+        if name in lazy_attrs:
+            module = import_module(lazy_attrs[name])
+            value = getattr(module, name)
+            module_globals[name] = value
+            return value
+        if name in submodules:
+            module = import_module(submodules[name])
+            module_globals[name] = module
+            return module
+        raise AttributeError(f"module {module_name!r} has no attribute {name!r}")
+
+    def __dir__() -> List[str]:
+        return sorted(set(module_globals) | set(all_names) | set(submodules))
+
+    return all_names, __getattr__, __dir__


### PR DESCRIPTION
Refactor module imports to use lazy loading for improved performance

- Updated multiple `__init__.py` files across various modules to implement lazy loading of imports using `importlib`.
- This change enhances the efficiency of the module loading process by deferring the import of submodules until they are actually accessed.
- Adjusted the `__all__` and `__getattr__` methods accordingly to support the new lazy loading mechanism.