### PR TITLE
fix known bugs

### DIFF
--- a/rllm/data/graph_data.py
+++ b/rllm/data/graph_data.py
@@ -42,9 +42,6 @@ class BaseGraph:
 
     @property
     def device(self) -> torch.device:
-        if "_device" in self.__dict__:
-            return self.__dict__["_device"]
-
         for store in self.stores:
             for _, value in store.items():
                 if isinstance(value, Tensor):
@@ -57,19 +54,12 @@ class BaseGraph:
 
         return torch.device("cpu")
 
-    @device.setter
-    def device(self, value: Union[int, str, torch.device]):
-        if isinstance(value, int):
-            value = f"cuda:{value}"
-        self.__dict__["_device"] = torch.device(value)
-
     def clone(self, *args: str):
         r"""Performs cloning of tensors for the ones given in `*args`"""
         return copy.copy(self).apply(lambda x: x.clone(), *args)
 
     def to(self, device: Union[int, str], *args: str, non_blocking: bool = False):
         r"""Performs device conversion of the whole dataset."""
-        self.device = f"cuda:{device}" if isinstance(device, int) else device
         return self.apply(
             lambda x: x.to(device=device, non_blocking=non_blocking), *args
         )

--- a/rllm/data/graph_data.py
+++ b/rllm/data/graph_data.py
@@ -40,6 +40,29 @@ class BaseGraph:
     def stores(self):
         raise NotImplementedError
 
+    @property
+    def device(self) -> torch.device:
+        if "_device" in self.__dict__:
+            return self.__dict__["_device"]
+
+        for store in self.stores:
+            for _, value in store.items():
+                if isinstance(value, Tensor):
+                    return value.device
+                if hasattr(value, "device"):
+                    try:
+                        return torch.device(value.device)
+                    except (TypeError, ValueError):
+                        pass
+
+        return torch.device("cpu")
+
+    @device.setter
+    def device(self, value: Union[int, str, torch.device]):
+        if isinstance(value, int):
+            value = f"cuda:{value}"
+        self.__dict__["_device"] = torch.device(value)
+
     def clone(self, *args: str):
         r"""Performs cloning of tensors for the ones given in `*args`"""
         return copy.copy(self).apply(lambda x: x.clone(), *args)
@@ -667,7 +690,11 @@ class HeteroGraphData(BaseGraph):
         is_sorted: bool = False,
         node_time_d: Optional[Dict[NodeType, Tensor]] = None,
         edge_time_d: Optional[Dict[EdgeType, Tensor]] = None,
-    ) -> Tuple[Dict[str, Tensor], Dict[str, Tensor], Dict[str, Optional[Tensor]]]:
+    ) -> Tuple[
+        Dict[EdgeType, Tensor],
+        Dict[EdgeType, Tensor],
+        Dict[EdgeType, Optional[Tensor]],
+    ]:
         r"""Convert the heterogeneous graph edge into a CSC format for sampling.
         Returns dictionaries holding `colptr` and `row` indices as well as edge
         permutations for each edge type, respectively.
@@ -697,7 +724,7 @@ class HeteroGraphData(BaseGraph):
             edge_time = (edge_time_d or {}).get(edge_type, None)
             out = store.to_csc(
                 device=device,
-                num_nodes=self[edge_type[0]].num_nodes,
+                num_nodes=self[edge_type[2]].num_nodes,
                 share_memory=share_memory,
                 is_sorted=is_sorted,
                 src_node_time=src_node_time,

--- a/rllm/data/storage.py
+++ b/rllm/data/storage.py
@@ -253,10 +253,17 @@ class EdgeStorage(BaseStorage):
             return True
 
         v = self[key]
-        if (
-            isinstance(v, (list, tuple, "TableData"))  # avoid circular import
-            and len(v) == self.num_edges
-        ):
+
+        # Lazy import keeps `storage.py` decoupled from `table_data.py`.
+        try:
+            from rllm.data.table_data import TableData
+
+            edge_attr_type = (list, tuple, TableData)
+        except Exception:
+            warn("TableData not found. Using list and tuple as edge attribute type.")
+            edge_attr_type = (list, tuple)
+
+        if isinstance(v, edge_attr_type) and len(v) == self.num_edges:
             self._edge_attr_cache.add(key)
             return True
 

--- a/rllm/data/table_data.py
+++ b/rllm/data/table_data.py
@@ -552,7 +552,7 @@ class TableData(BaseTable):
             ), "when start and end are ratios, \
                 they must be between 0 and 1!"
             start_row = int(round(self.num_rows * start))
-            end_row = int(start + round(self.num_rows * (end - start)))
+            end_row = int(start_row + round(self.num_rows * (end - start)))
         feat_dict = {}
         # Get tensors corresponding to each in ColType
         for col_type in self.feat_dict.keys():

--- a/rllm/dataloader/neighbor_loader.py
+++ b/rllm/dataloader/neighbor_loader.py
@@ -81,6 +81,8 @@ class NeighborLoader(torch.utils.data.DataLoader):
             edge_index = data.edge_index
         elif hasattr(data, "adj"):
             edge_index = data.adj.coalesce().indices()
+        else:
+            raise ValueError("Graph data must have edge_index or adj attribute.")
         order = torch.argsort(edge_index[1])
         self.dst_sorted = edge_index[1][order]
         self.src_sorted = edge_index[0][order]

--- a/rllm/nn/conv/graph_conv/message_passing.py
+++ b/rllm/nn/conv/graph_conv/message_passing.py
@@ -76,6 +76,7 @@ class MessagePassing(torch.nn.Module, ABC):
             >>> out.shape
             torch.Size([5, 8])
         """
+        self.__validate_edgeindex__(edge_index)
 
         # Infer aggregator dim_size
         if "dim_size" not in kwargs or kwargs["dim_size"] is None:
@@ -204,15 +205,22 @@ class MessagePassing(torch.nn.Module, ABC):
         r"""Unify the edge index to a 2D tensor."""
         if edge_index.is_sparse:
             return self.__adj_to_edges__(edge_index)
-        elif edge_index.size(0) != 2:
-            try:
-                return self.__adj_to_edges__(edge_index)
-            except ValueError:
-                raise ValueError(
-                    f"Expect edge_index to be a 2D tensor, got {edge_index.size()}."
-                )
-        else:
-            return edge_index, None
+        self.__validate_edgeindex__(edge_index)
+        return edge_index, None
+
+    def __validate_edgeindex__(self, edge_index: Union[Tensor, SparseTensor]) -> None:
+        r"""Validate edge index inputs before message passing."""
+        if edge_index.is_sparse:
+            return
+        if edge_index.dim() != 2:
+            raise ValueError(
+                "Expect edge_index to be a 2D tensor with shape "
+                f"[2, num_edges], got {edge_index.size()}."
+            )
+        if edge_index.size(0) != 2:
+            raise ValueError(
+                f"Expect edge_index to have shape [2, num_edges], got {edge_index.size()}."
+            )
 
     def __adj_to_edges__(self, adj: SparseTensor) -> Tuple[Tensor, Tensor]:
         r"""Converts a sparse adjacency matrix to edge indices."""

--- a/rllm/nn/conv/graph_conv/relgnn_conv.py
+++ b/rllm/nn/conv/graph_conv/relgnn_conv.py
@@ -1,3 +1,6 @@
+from typing import Optional, Tuple, Union
+
+from torch import Tensor
 from torch.nn import Linear
 
 from .transformer_conv import GTransformerConv
@@ -23,6 +26,7 @@ class RelGNNConv(GTransformerConv):
             edges. (default: :obj:`False`)
         bias (bool): Whether to add a bias term. (default: :obj:`True`)
     """
+    aggr_conv: Optional[SAGEConv]
 
     def __init__(
         self,
@@ -35,8 +39,9 @@ class RelGNNConv(GTransformerConv):
         bias=True,
         **kwargs,
     ):
+        attn_in_dim = (out_dim, in_dim) if attn_type == "dim-fact-dim" else (in_dim, in_dim)
         super().__init__(
-            in_dim=(in_dim, in_dim),
+            in_dim=attn_in_dim,
             out_dim=out_dim,
             num_heads=num_heads,
             bias=bias,
@@ -55,15 +60,16 @@ class RelGNNConv(GTransformerConv):
         r"""Resets all learnable parameters of the module."""
         self.final_proj.reset_parameters()
         if self.attn_type == "dim-fact-dim":
+            assert self.aggr_conv is not None
             self.aggr_conv.reset_parameters()
         return super().reset_parameters()
 
     def forward(
         self,
-        x,
-        edge_index,
-        edge_weight=None,
-        return_attention_weights=False,
+        x: Union[Tensor, Tuple[Tensor, Tensor], Tuple[Tensor, Tensor, Tensor]],
+        edge_index: Union[Tensor, Tuple[Tensor, Tensor]],
+        edge_weight: Optional[Tensor] = None,
+        return_attention_weights: bool = False,
     ):
         r"""Run RelGNN attention with optional factorized message passing.
 
@@ -94,6 +100,8 @@ class RelGNNConv(GTransformerConv):
         """
         # dim-dim
         if self.attn_type == "dim-dim":
+            assert isinstance(edge_index, Tensor)
+            assert isinstance(x, Tensor) or (isinstance(x, tuple) and len(x) == 2)
             if self.simplified_MP and edge_index.shape[1] == 0:
                 return None
             out = super().forward(x, edge_index, edge_weight, return_attention_weights)
@@ -103,6 +111,10 @@ class RelGNNConv(GTransformerConv):
             return self.final_proj(out)
 
         # dim-fact-dim
+        assert isinstance(edge_index, tuple) and len(edge_index) == 2
+        assert isinstance(x, tuple) and len(x) == 3
+        assert self.aggr_conv is not None
+
         edge_attn, edge_aggr = edge_index
 
         src_aggr, dst_aggr, dst_attn = x
@@ -110,13 +122,9 @@ class RelGNNConv(GTransformerConv):
         if self.simplified_MP:
             if edge_attn.shape[1] == 0:
                 return None
-
-            if edge_aggr.shape[1] == 0:
-                src_attn = dst_aggr
-            else:
-                src_attn = self.aggr_conv((src_aggr, dst_aggr), edge_aggr)
-        else:
-            src_attn = self.aggr_conv((src_aggr, dst_aggr), edge_aggr)
+        # Always project the aggregated source features to `out_dim` before
+        # the transformer attention path, even when `edge_aggr` is empty.
+        src_attn = self.aggr_conv((src_aggr, dst_aggr), edge_aggr)
 
         out = super().forward(
             (src_attn, dst_attn), edge_attn, edge_weight, return_attention_weights

--- a/test/data/test_graph_data.py
+++ b/test/data/test_graph_data.py
@@ -3,7 +3,7 @@ import numpy as np
 import torch
 
 from rllm.types import ColType
-from rllm.data import HeteroGraphData, TableData
+from rllm.data import EdgeStorage, HeteroGraphData, TableData
 
 
 def test_heterographdata():
@@ -39,3 +39,27 @@ def test_heterographdata():
     assert id(hgraph2["node1"].x) == id(hgraph["node1"].x)
     hgraph2["node1"].x = torch.tensor([1.2, 2.2])
     assert id(hgraph2["node1"].x) != id(hgraph["node1"].x)
+
+
+def test_heterographdata_to_csc_dict_uses_dst_num_nodes():
+    hgraph = HeteroGraphData()
+    hgraph["src"].num_nodes = 2
+    hgraph["dst"].num_nodes = 4
+    hgraph[("src", "to", "dst")].edge_index = torch.tensor(
+        [[0, 1], [0, 3]], dtype=torch.long
+    )
+
+    col_ptr_d, row_d, perm_d = hgraph.to_csc_dict()
+
+    edge_type = ("src", "to", "dst")
+    assert torch.equal(col_ptr_d[edge_type], torch.tensor([0, 1, 1, 1, 2]))
+    assert torch.equal(row_d[edge_type], torch.tensor([0, 1]))
+    assert perm_d[edge_type] is not None
+
+
+def test_edge_storage_is_edge_attr_accepts_tensor_weight():
+    storage = EdgeStorage()
+    storage.edge_index = torch.tensor([[0, 1], [1, 0]], dtype=torch.long)
+    storage.weight = torch.tensor([0.1, 0.2])
+
+    assert storage.is_edge_attr("weight")


### PR DESCRIPTION
1. EdgeStorage.is_edge_attr() `isinstance(v, (list, tuple, "TableData"))` — string in isinstance raises TypeError.    — Fixed, Lazy import of `TableData` class, matching `is_node_attr()` pattern.  
2. NeighborLoader data.device `self.device = data.device` fails when `GraphData` never called `.to()`. -- Add default value
3. TableData.save/load with pkey _unify_valid_pkey() fails on load because df.index.name is lost. -- False alarm
4. TableData.get_feat_dict() float range-- Fixed  
5.  to_csc_dict() use edge_type[1]
6. add __validate_edgeindex__ to avoid unexpected edgeindex input
7. fix relgnn conv dim unmatched bug